### PR TITLE
Free channel when user leaves it

### DIFF
--- a/irc.h
+++ b/irc.h
@@ -245,8 +245,10 @@ typedef struct irc_plugin {
 	void (*irc_free)(irc_t *irc);
 	/* At the end of account_add */
 	void (*account_add)(struct account *acc);
-	/* At the end of channel_new */
+	/* At the end of irc_channel_new */
 	void (*channel_new)(irc_channel_t *channel);
+	/* At the end of irc_channel_del_user */
+	void (*channel_part)(irc_channel_t *channel);
 
 	/* Problem with the following two functions is ordering if multiple
 	   plugins are handling them. Let's keep fixing that problem for

--- a/irc_channel.c
+++ b/irc_channel.c
@@ -266,6 +266,7 @@ int irc_channel_add_user(irc_channel_t *ic, irc_user_t *iu)
 int irc_channel_del_user(irc_channel_t *ic, irc_user_t *iu, irc_channel_del_user_type_t type, const char *msg)
 {
 	irc_channel_user_t *icu;
+	GSList *l;
 
 	if (!(icu = irc_channel_has_user(ic, iu))) {
 		if (iu == ic->irc->user && type == IRC_CDU_KICK) {
@@ -302,6 +303,14 @@ int irc_channel_del_user(irc_channel_t *ic, irc_user_t *iu, irc_channel_del_user
 				ic->users = g_slist_remove(ic->users, ic->users->data);
 			}
 			irc_channel_add_user(ic, ic->irc->root);
+
+			/* Allow plugins to register settings */
+			for (l=irc_plugins; l; l=l->next) {
+				irc_plugin_t *p = l->data;
+				if (p->channel_part) {
+					p->channel_part(ic);
+				}
+			}
 		}
 	}
 

--- a/plugins/enterprise_jabber_proxy.c
+++ b/plugins/enterprise_jabber_proxy.c
@@ -128,6 +128,13 @@ void jabber_account_add(account_t *acc)
 	}
 }
 
+void jabber_channel_part(irc_channel_t *ic)
+{
+	/* If the user leaves the conference room, we can simply delete it.
+	 * Whenever they want to come back, a simple /join will just work */
+	irc_channel_free(ic);
+}
+
 void jabber_channel_new(irc_channel_t *ic)
 {
 	/* XXX segfaults when trying to /join before auth */
@@ -167,6 +174,7 @@ static const struct irc_plugin jabber_proxy_plugin =
 	.storage_load = jabber_storage_load,
 	.account_add = jabber_account_add,
 	.channel_new = jabber_channel_new,
+	.channel_part = jabber_channel_part,
 };
 
 void init_plugin(void)


### PR DESCRIPTION
When the user is using the enterprise jabber proxy plugin, channels are created on the fly when user joins it. Therefore, when the user leaves it, we have no reason to keep it. We can delete it, and it will be
recreated whenever the user re-joins.
